### PR TITLE
Working EventLoop by fixing Framework NSString* constant NSDefaultRunLoopMode

### DIFF
--- a/examples/EventLoop.js
+++ b/examples/EventLoop.js
@@ -1,0 +1,125 @@
+var $, EventEmitter = require('events').EventEmitter;
+
+// export EventLoop at module and as 'EventLoop'
+module.exports = EventLoop.EventLoop = EventLoop
+EventLoop.initObjC = function(NodObjC) {
+  $ = NodObjC || $ || require('NodObjC')
+  $.import('Cocoa')
+
+  EventLoop.prototype._runLoopMode = $.NSDefaultRunLoopMode
+  if (EventLoop.prototype._runLoopMode === null) {
+    EventLoop.prototype._runLoopMode = $('kCFRunLoopDefaultMode')
+    console.warn('WARNING: Falling back to hard-coded string for NSDefaultRunLoopMode constant. See https://github.com/TooTallNate/NodObjC/pull/56 for details.')
+  }
+}
+
+function EventLoop(start, options) {
+  EventEmitter.call(this)
+  if (options) {
+    if (options.runLoopMode) this._runLoopMode = options.runLoopMode
+  }
+  this.runInfo = {recurring:null, schedule_id:null, loop:{}}
+
+  if (start) this.start()
+  return this
+}
+require('util').inherits(EventLoop, EventEmitter)
+
+EventLoop.prototype.start = function() {
+  this.emit('start')
+  return this.schedule(true)
+}
+EventLoop.prototype.stop = function() {
+  this.runInfo.recurring = false
+  this.emit('stop')
+  return this
+}
+EventLoop.prototype._schedule = setTimeout
+EventLoop.prototype._clearSchedule = clearTimeout
+EventLoop.prototype.schedule = function(runRecurring) {
+  var runInfo = this.runInfo
+  if (runRecurring !== undefined)
+    runInfo.recurring = !!runRecurring
+
+  if (runInfo.schedule_id != null)
+    return this; // exit if already scheduled
+
+  var id = this._schedule(this.eventLoop.bind(this))
+  runInfo.schedule_id = (id !== undefined) ? id : true
+  this.emit('scheduled', runInfo)
+  return this
+}
+EventLoop.prototype.clearSchedule = function() {
+  var runInfo = this.runInfo
+  var id = runInfo.schedule_id
+  runInfo.recurring = false
+
+  if (id != null) {
+    runInfo.schedule_id = null
+    this._clearSchedule(id)
+    this.emit('unscheduled', runInfo)
+  }
+  return this
+}
+
+EventLoop.prototype.isScheduled = function(runInfo) {
+  if (!runInfo) runInfo = this.runInfo
+  return runInfo.schedule_id!=null }
+EventLoop.prototype.isActive = function(runInfo) {
+  if (!runInfo) runInfo = this.runInfo
+  return this.isScheduled(runInfo) || runInfo.recurring }
+
+EventLoop.prototype.eventLoop = function(runRecurring) {
+  var runInfo = this.runInfo
+  runInfo.schedule_id = null
+  this.eventLoopCore()
+  if (runInfo.recurring || runRecurring)
+    this.schedule(runRecurring)
+  else if (runInfo.schedule_id==null)
+    this.emit('deactivate', this.runInfo)
+  return this
+}
+EventLoop.prototype.eventLoopCore = function(block) {
+  if ($==null) EventLoop.initObjC();
+
+  var runInfo = this.runInfo,
+      loopInfo = {running:true, count:0, t0:Date.now()},
+      event, app = $.NSApplication('sharedApplication'),
+      untilDate = block ? $.NSDate('distantFuture') : null, // or $.NSDate('distantPast') to not block
+      inMode = this._runLoopMode
+
+  var runLoopPool = $.NSAutoreleasePool('alloc')('init')
+  try {
+    runInfo.loop = loopInfo
+    this.emit('eventLoop-enter', runInfo)
+    do {
+      this.emit('event-next', event, app, runInfo)
+      event = app('nextEventMatchingMask',
+              $.NSAnyEventMask.toString(), // …grumble… uint64 as string …grumble…
+              'untilDate', untilDate,
+              'inMode', inMode,
+              'dequeue', 1)
+      this.emit('event-match', event, app, runInfo)
+      if (event) {
+        app('sendEvent', event)
+        this.emit('event-sent', event, app, runInfo)
+      }
+      ++loopInfo.count
+    } while (event)
+    loopInfo.t1 = Date.now()
+    loopInfo.running = false
+    this.emit('eventLoop-exit', runInfo)
+  } catch (err) {
+    loopInfo.t1 = Date.now()
+    loopInfo.running = false
+    loopInfo.error = err
+    this.emit('error', err, runInfo)
+    throw err
+  } finally {
+    runLoopPool('drain')
+  }
+  delete loopInfo.running
+  this.emit('eventLoop', runInfo)
+  return this
+}
+

--- a/examples/NodeCocoaHelloWorld.app/Contents/MacOS/app.js
+++ b/examples/NodeCocoaHelloWorld.app/Contents/MacOS/app.js
@@ -2,11 +2,14 @@
 // blog article:
 //    http://cocoawithlove.com/2010/09/minimalist-cocoa-programming.html
 var $ = require('../../../../')
+var EventLoop = require('../../../EventLoop')
+EventLoop.initObjC($)
 
 $.import('Cocoa')
 
 var pool = $.NSAutoreleasePool('alloc')('init')
   , app  = $.NSApplication('sharedApplication')
+  , evtLoop = new EventLoop()
 
 app('setActivationPolicy', $.NSApplicationActivationPolicyRegular)
 
@@ -53,4 +56,6 @@ var delegate = AppDelegate('alloc')('init')
 app('setDelegate', delegate)
 
 app('activateIgnoringOtherApps', true)
-app('run')
+app('finishLaunching')
+
+evtLoop.start()

--- a/lib/import.js
+++ b/lib/import.js
@@ -187,10 +187,9 @@ module.exports = (function() {
         var type = getType(node);
         onto.__defineGetter__(name, function () {
           var ptr = fw.lib.get(name);
-          ptr._type = '^' + type;
-          var derefPtr = ptr.deref();
+          var derefPtr = core.REF.get(ptr, 0, core.Types.map(type))
           delete onto[name];
-          return onto[name] = derefPtr;
+          return onto[name] = core.wrapValue(derefPtr, type);
         });
       }
       else if (node.name == 'function')

--- a/test/eventLoop.js
+++ b/test/eventLoop.js
@@ -1,0 +1,107 @@
+// Test inspired by ./nstimer.js, but using node-friendly deconstructed event loop
+
+var $ = require('../')
+  , assert = require('assert')
+  , util = require('util')
+  , events = require('events')
+
+$.import('Foundation')
+$.import('Cocoa')
+
+function EventLoop(start) {
+  events.EventEmitter.call(this)
+
+  assert.equal($.NSDefaultRunLoopMode, 'kCFRunLoopDefaultMode')
+
+  if (start) this.start();
+  return this
+}
+util.inherits(EventLoop, events.EventEmitter)
+
+EventLoop.prototype.start = function() {
+  this.emit('start')
+  return this.schedule(true)
+}
+EventLoop.prototype.stop = function() {
+  this._is_running = false
+  this.emit('stop')
+  return this
+}
+EventLoop.prototype._schedule = setTimeout
+EventLoop.prototype.schedule = function(runRecurring) {
+  if (runRecurring !== undefined)
+    this._is_running = runRecurring
+  var memento = this._schedule(this.eventLoop.bind(this))
+  this.emit('scheduled', memento, this._is_running)
+  return this
+}
+
+EventLoop.prototype.eventLoop = function(runRecurring) {
+  this.eventLoopCore()
+  if (this._is_running || runRecurring)
+    this.schedule(runRecurring)
+  return this
+}
+EventLoop.prototype.eventLoopCore = function(block) {
+  var untilDate = block ? $.NSDate('distantFuture') : null; // or $.NSDate('distantPast') to not block
+  var event, app = $.NSApplication('sharedApplication')
+  var runLoopPool = $.NSAutoreleasePool('alloc')('init')
+
+  var count = 0;
+  try {
+    this.emit('eventLoop-enter')
+    do {
+      this.emit('event-next', count)
+      event = app('nextEventMatchingMask',
+              $.NSAnyEventMask.toString(), // …grumble… uint64 as string …grumble…
+              'untilDate', untilDate,
+              'inMode', $.NSDefaultRunLoopMode,
+              'dequeue', 1)
+      this.emit('event-match', event, app, count)
+      if (event) {
+        app('sendEvent', event)
+        this.emit('event-sent', event, app, count)
+      }
+      ++count;
+    } while (event)
+    this.emit('eventLoop-exit', count)
+  } catch (err) {
+    this.emit('error', err)
+    throw err
+  } finally {
+    runLoopPool('drain')
+  }
+  return this;
+}
+
+
+
+var pool = $.NSAutoreleasePool('alloc')('init')
+
+var Obj = $.NSObject.extend('Obj')
+  , invokeCount = 0
+  , eventLoopCount = 0
+
+var evtLoop = new EventLoop()
+evtLoop.on('eventLoop-exit', function(count) { eventLoopCount += count })
+
+Obj.addMethod('sel:', 'v@:@', function (self, _cmd, timer) {
+  assert.equal('Info', timer('userInfo').toString())
+  if (++invokeCount == 5) {
+    timer('invalidate');
+    evtLoop.stop()
+  }
+}).register()
+
+var timer = $.NSTimer('scheduledTimerWithTimeInterval', 0.1
+                     ,'target', Obj('alloc')('init')
+                     ,'selector', 'sel:'
+                     ,'userInfo', $('Info')
+                     ,'repeats', 1)
+
+process.on('exit', function () {
+  assert.equal(invokeCount, 5)
+  assert(eventLoopCount > invokeCount, eventLoopCount+' evts > '+invokeCount+' timers')
+})
+
+evtLoop.start()

--- a/test/resolveFrameworkConstants.js
+++ b/test/resolveFrameworkConstants.js
@@ -1,0 +1,10 @@
+var $ = require('..');
+var assert = require('assert');
+$.framework('Foundation');
+var pool = $.NSAutoreleasePool('alloc')('init');
+
+// in NodObjC v1.0.0, NSString* constants loaded from frameworks return null
+assert.equal($.NSDefaultRunLoopMode, 'kCFRunLoopDefaultMode')
+
+pool('drain');
+


### PR DESCRIPTION
Having implemented asynchronous event loops before, I was investigating why @JeanSebTr's code example in  issue #53 was not working. Poking around with PyObjC, the value of `NSDefaultRunLoopMode` should have been "kCFRunLoopDefaultMode", but was coming back `null`. Using PyObjC's implementation to troubleshoot, I was able to create a patch for constant resolving in `lib/import.js` that fixes the problem. It also enables a node-friendly Cocoa application event loop to address issue #53 and #2.