### PR TITLE
Update template.jade

### DIFF
--- a/docs/template.jade
+++ b/docs/template.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title #{title} | NodObjC v#{package.version}


### PR DESCRIPTION
Jade doesn't like 'doctype 5' anymore.

Similar issue mentioned here: https://github.com/expressjs/express/issues/1931