### PR TITLE
Node 12/Electron 9 support

### DIFF
--- a/lib/class.js
+++ b/lib/class.js
@@ -3,7 +3,7 @@ module.exports = Class;
 /*!
  * Module dependencies.
  */
-var ref = require('ref');
+var ref = require('ref-napi');
 var createFunction = require('function-class');
 
 var core = require('./core');

--- a/lib/core.js
+++ b/lib/core.js
@@ -113,7 +113,7 @@ function getClassList () {
 
   if (num > 0) {
     var c = null;
-    var classes = new Buffer(ref.sizeof.pointer * num);
+    var classes = new Buffer.alloc(ref.sizeof.pointer * num);
 
     objc.objc_getClassList(classes, num);
 
@@ -371,14 +371,17 @@ function createObject (val, type, name) {
   if (!val || ref.isNull(val)) return null;
 
   var cache = objc.objc_getAssociatedObject(val, objc.objcStorageKey);
-  if (!ref.isNull(cache)) return cache.readObject(0);
+  if (!ref.isNull(cache)) {
+    let instance = cache.readObject(0);
+    if(instance) return instance;
+  }
 
   var instance = (type == '@') ? new (require('./id'))(val)
                         : new (require('./class'))(val);
 
   // store this ID JS reference into the Obj-C internal associated object store
   var refn = ref.alloc('Object');
-  refn.writeObject(refn, 0, instance);
+  ref.writeObject(refn, 0, instance);
   objc.objc_setAssociatedObject(val, objc.objcStorageKey, refn, 0);
 
   return instance;
@@ -404,6 +407,6 @@ objc.wrapValue = wrapValue;
 objc.wrapValues = wrapValues;
 objc.unwrapValues = unwrapValues;
 objc.unwrapValue = unwrapValue;
-objc.objcStorageKey = new Buffer(1);
+objc.objcStorageKey = new Buffer.alloc(1);
 
 module.exports = objc;

--- a/lib/core.js
+++ b/lib/core.js
@@ -11,10 +11,10 @@
  * Module dependencies.
  */
 
-var ref = require('ref')
-  , ffi = require('ffi')
+var ref = require('ref-napi')
+  , ffi = require('ffi-napi')
   , types = require('./types')
-  , Struct = require('ref-struct')
+  , Struct = require('ref-struct-napi')
   , uintptr_t = ref.sizeof.pointer == 8 ? 'uint64' : 'uint32' // 'uintptr_t' isn't natively supported by node-ffi
   , libc = new ffi.Library('libc', {
       malloc: [ 'void*', [ 'size_t' ] ]
@@ -377,8 +377,8 @@ function createObject (val, type, name) {
                         : new (require('./class'))(val);
 
   // store this ID JS reference into the Obj-C internal associated object store
-  var refn = ref.alloc('pointer');
-  refn.writeObject(instance, 0);
+  var refn = ref.alloc('Object');
+  refn.writeObject(refn, 0, instance);
   objc.objc_setAssociatedObject(val, objc.objcStorageKey, refn, 0);
 
   return instance;

--- a/lib/id.js
+++ b/lib/id.js
@@ -253,7 +253,7 @@ ID.prototype.ivar = function (name, value) {
     var unwrapped = core.unwrapValue(value, ivar.getTypeEncoding());
     return core.object_setIvar(this.pointer, ivar.pointer, unwrapped);
   } else {
-    var ptr = new Buffer(ref.sizeof.pointer);
+    var ptr = new Buffer.alloc(ref.sizeof.pointer);
     var ivar = core.object_getInstanceVariable(this.pointer, name, ptr);
     return core.wrapValue(ptr.readPointer(0), core.ivar_getTypeEncoding(ivar));
   }

--- a/lib/id.js
+++ b/lib/id.js
@@ -4,8 +4,8 @@ module.exports = ID;
  * Module dependencies.
  */
 
-var ref = require('ref');
-var Struct = require('ref-struct');
+var ref = require('ref-napi');
+var Struct = require('ref-struct-napi');
 var createFunction = require('function-class');
 var invoke = require('function-class/invoke');
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -13,7 +13,7 @@
  * Module dependencies.
  */
 var fs = require('fs')
-  , ref = require('ref')
+  , ref = require('ref-napi')
   , read = fs.readFileSync
   , path = require('path')
   , core = require('./core')

--- a/lib/ivar.js
+++ b/lib/ivar.js
@@ -8,7 +8,7 @@ module.exports = Ivar;
  * Module dependencies.
  */
 
-var ref = require('ref');
+var ref = require('ref-napi');
 var core = require('./core');
 
 /**

--- a/lib/method.js
+++ b/lib/method.js
@@ -9,7 +9,7 @@ module.exports = Method;
  * Module dependencies.
  */
 
-var ref = require('ref');
+var ref = require('ref-napi');
 var core = require('./core');
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -21,7 +21,7 @@
 /*!
  * Module dependencies.
  */
-var Struct = require('ref-struct');
+var Struct = require('ref-struct-napi');
 var assert = require('assert');
 var test = /^\{.*?\}$/;
 var structCache = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,317 @@
+{
+  "name": "nodobjc",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+      "dev": true
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "dox": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/dox/-/dox-0.3.3.tgz",
+      "integrity": "sha1-vQGB2JSNMh3YIm7nduvW4BBDkf8=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "github-flavored-markdown": ">= 0.0.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
+      }
+    },
+    "ffi-napi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-3.0.1.tgz",
+      "integrity": "sha512-zOvTqC9pjXNfVUruk4phi+Itayg3yefgiR/CZtr09OcrYulBq9jeUtf/GvFeXfNRv8q2qu3+ijMPj4rewTWbVg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1",
+        "ref-struct-di": "^1.1.0"
+      }
+    },
+    "function-class": {
+      "version": "github:TooTallNate/node-function-class#de55e97c85a51e9ee09497df93155e73a06f0a68",
+      "from": "github:TooTallNate/node-function-class#pull/1/head",
+      "requires": {
+        "es6-symbol": "^3.1.1",
+        "setprototypeof": "^1.1.1"
+      }
+    },
+    "function-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/function-name/-/function-name-2.0.0.tgz",
+      "integrity": "sha1-X15Syz7vIuTnU4NFN/X4PTuLD84="
+    },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
+    "github-flavored-markdown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/github-flavored-markdown/-/github-flavored-markdown-1.0.1.tgz",
+      "integrity": "sha1-kzYbh6McJXkNnIGht5ghSnN+qzg=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-1.2.0.tgz",
+      "integrity": "sha1-XWgcrGpnPune6I/t73ydxm9A7Yg=",
+      "dev": true,
+      "requires": {
+        "commander": "*"
+      }
+    },
+    "jade": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.25.0.tgz",
+      "integrity": "sha1-pZ8vTgeqP/imzi51nvA5hmhkoa4=",
+      "dev": true,
+      "requires": {
+        "commander": "0.5.2",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.5.2.tgz",
+          "integrity": "sha1-8nAyZwmhFaEmz+1WI4UkObjko7U=",
+          "dev": true
+        }
+      }
+    },
+    "libxmljs": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.14.3.tgz",
+      "integrity": "sha1-oImwtcOBpcJcUSpzcbcyJSgtiI4=",
+      "dev": true,
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.0.7"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.7.tgz",
+          "integrity": "sha1-xybORdvYY7RiNOTf5b8C0MswnNg=",
+          "dev": true
+        }
+      }
+    },
+    "marked": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.2.10.tgz",
+      "integrity": "sha1-1f1oJxyq5hxV0pHQe9UDTP9ec+4=",
+      "dev": true
+    },
+    "memwatch-next": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/memwatch-next/-/memwatch-next-0.3.0.tgz",
+      "integrity": "sha1-IREFD5qQbgqi1ypOwPAInHhyb48=",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.3.2"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+    },
+    "ref-napi": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-2.0.3.tgz",
+      "integrity": "sha512-zsAhPhh9gUlk0pP5iR9nhvwFeC/E9G1X0cdH/qQRTwx3VDgVi40Aflq/EdbobcVg++RNaMxZsbaQV+/E2u57LQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.1"
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "ref-struct-napi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-napi/-/ref-struct-napi-1.1.1.tgz",
+      "integrity": "sha512-YgS5/d7+kT5zgtySYI5ieH0hREdv+DabgDvoczxsui0f9VLm0rrDcWEj4DHKehsH+tJnVMsLwuyctWgvdEcVRw==",
+      "requires": {
+        "debug": "2",
+        "ref-napi": "^1.4.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "ref-napi": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.5.2.tgz",
+          "integrity": "sha512-hwyNmWpUkt1bDWDW4aiwCoC+SJfJO69UIdjqssNqdaS0sYJpgqzosGg/rLtk69UoQ8drZdI9yyQefM7eEMM3Gw==",
+          "requires": {
+            "debug": "^3.1.0",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        }
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ffi",
     "bridge"
   ],
-  "os": [ 
+  "os": [
     "darwin"
   ],
   "version": "2.1.0",
@@ -28,11 +28,12 @@
     "test": "./test/run.sh test/*.js"
   },
   "dependencies": {
+    "ffi-napi": "^3.0.1",
     "debug": "*",
-    "ffi": "2",
-    "function-class": "^1.0.0",
-    "ref": "^1.3.2",
-    "ref-struct": "^1.0.2",
+    "function-name": "^2.0.0",
+    "function-class": "github:TooTallNate/node-function-class#pull/1/head",
+    "ref-napi": "^2.0.3",
+    "ref-struct-napi": "^1.1.1",
     "setprototypeof": "^1.0.0"
   },
   "devDependencies": {

--- a/test/archive/core/createInstance.js
+++ b/test/archive/core/createInstance.js
@@ -1,4 +1,4 @@
-var ffi = require('node-ffi')
+var ffi = require('ffi-napi')
   , assert = require('assert')
   , b = require('../../lib/core')
 

--- a/test/archive/core/introspection.js
+++ b/test/archive/core/introspection.js
@@ -1,5 +1,5 @@
 var b = require('../../lib/core')
-  , ffi = require('node-ffi')
+  , ffi = require('ffi-napi')
   , assert = require('assert')
   , className = 'NSMutableArray'
 

--- a/test/cast-buffer.js
+++ b/test/cast-buffer.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 
 $.framework('Foundation');
 
-var data = new Buffer('hello world');
+var data = new Buffer.from('hello world');
 var nsdata = $(data);
 var bytes = nsdata('bytes');
 


### PR DESCRIPTION
This pull request tries to fix Node 12 and Electron 9 issues (#118 ).
Generally it uses forks of several dependencies: `ref` (`ref-napi`), `ref-struct` (`ref-struct-napi`), `node-ffi` (`ffi-napi`). 
`function-class` dependency refers to a pull request now as this PR has a fix for Node 12 compatibility issues.
Besides that there is another fix for a crash